### PR TITLE
styled-reset 적용과 reset 해야할 style 관리

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-router-dom": "^6.3.0",
-    "styled-components": "^5.3.5"
+    "styled-components": "^5.3.5",
+    "styled-reset": "^4.4.1"
   },
   "devDependencies": {
     "@babel/core": "^7.17.10",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,13 @@
 import RouteList from './routes'
 import Layout from './components/common/Layout'
-
+import GlobalStyle from 'src/styles/GlobalStyle'
 export const App = () => {
   return (
-    <Layout>
-      <RouteList />
-    </Layout>
+    <>
+      <GlobalStyle />
+      <Layout>
+        <RouteList />
+      </Layout>
+    </>
   )
 }

--- a/src/components/common/Layout.js
+++ b/src/components/common/Layout.js
@@ -10,10 +10,12 @@ const Layout = (props) => {
   const { children } = props
 
   return (
-    <Wrap>
-      <Header />
-      {children}
-    </Wrap>
+    <>
+      <Wrap>
+        <Header />
+        {children}
+      </Wrap>
+    </>
   )
 }
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,7 +3,8 @@ import { Suspense } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import CssBaseline from '@mui/material/CssBaseline'
-import './reset.css'
+// import './reset.css'
+
 // import { ReactQueryDevtools } from 'react-query/devtools'
 // import { QueryClient, QueryClientProvider } from 'react-query'
 

--- a/src/reset.css
+++ b/src/reset.css
@@ -127,3 +127,8 @@ table {
   border-collapse: collapse;
   border-spacing: 0;
 }
+a {
+  text-decoration: none;
+  cursor: pointer;
+  color: inherit;
+}

--- a/src/styles/GlobalStyle.js
+++ b/src/styles/GlobalStyle.js
@@ -1,0 +1,14 @@
+import { createGlobalStyle } from 'styled-components'
+// eslint-disable-next-line import/no-named-as-default
+import reset from 'styled-reset'
+
+const GlobalStyle = createGlobalStyle`
+    ${reset};
+    a {
+      text-decoration: none;
+      cursor: pointer;
+      color: inherit;
+    }
+`
+
+export default GlobalStyle

--- a/yarn.lock
+++ b/yarn.lock
@@ -5301,6 +5301,11 @@ styled-components@^5.3.5:
     shallowequal "^1.1.0"
     supports-color "^5.5.0"
 
+styled-reset@^4.4.1:
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/styled-reset/-/styled-reset-4.4.1.tgz#c7b3aa247d4f8c5d14f1dc72fde9d02b8bee1758"
+  integrity sha512-7j99JIwzotNQmoS8MQJu8OTBDE48gaMEr6SYvuH8xfL0K/a5vNHSRaccTfAiGBs9D3mjLDPxg5iLh3HqFvefPQ==
+
 stylis@4.0.13:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/stylis/-/stylis-4.0.13.tgz#f5db332e376d13cc84ecfe5dace9a2a51d954c91"


### PR DESCRIPTION
### styled-reset 적용
#### 1. 적용 방법
  <code>import { createGlobalStyle } from 'styled-components'</code> 를 이용해서
```js
import { createGlobalStyle } from 'styled-components'
// eslint-disable-next-line import/no-named-as-default
import reset from 'styled-reset'

const GlobalStyle = createGlobalStyle`
    ${reset};
    a {
      text-decoration: none;
      cursor: pointer;
      color: inherit;
    }
`

export default GlobalStyle
```
이렇게 **글로벌하게 적용해서 사용할 수 있도록** 해두었습니다.
<code>src/styles/GlobalStyle.js</code>에 위치하고있고
<code>app.js</code>에 import 하여 적용해두었습니다. 

저희가 스타일 reset 필요하다고 느끼는 부분은
제가 a 태그 작성 해둔 것 처럼 이어서 작성 하시면 됩니다. 

( 여담이지만... http://meyerweb.com/eric/tools/css/reset 에서 제공하는 reset 에 a 태그 같은 애들은 없더라구요... ㅋㅋㅋㅋㅋㅋㅋㅋㅋㅋ... ㅜㅜㅜㅜ 
당연히.. reset에 포함될거라고 생각했는데....😭 )
 
#### 2. reset.css 로 적용해주면 되는데 왜 굳이 styled-reset을 적용했는가?🤔
 ${reset} 을 콘솔에 찍으면
<img width="433" alt="스크린샷 2022-06-10 오후 11 53 31" src="https://user-images.githubusercontent.com/57613408/173094310-19f04db5-be25-4e30-9471-a06bb5929f9e.png">
저희가 기존에 style.css 의 파일에 작성했던 (사실은 복붙하는...) 내용을 출력합니다. 
여기서 알 수 있듯이 
저희가 관리할 부분이 줄어들 것이라 생각해서 styled-reset 을 사용하였습니다. 

아무튼.. 다들 더 좋은 방법이 있으면 공유해주시고
회의 때 한번 더 이야기 나눠보고
제가 생각한게 괜찮다면 머지 하도록 하겠습니다. 

  

